### PR TITLE
Split Camel into two functions

### DIFF
--- a/kace.go
+++ b/kace.go
@@ -15,8 +15,17 @@ var (
 	ciTrie = newTrie(ciMap)
 )
 
-// Camel returns a camel cased string.
-func Camel(s string, ucFirst bool) string {
+// Camel returns a camelCased string.
+func Camel(s string) string {
+	return camel(s, false)
+}
+
+// Pascal returns a PascalCased string.
+func Pascal(s string) string {
+	return camel(s, true)
+}
+
+func camel(s string, ucFirst bool) string {
 	tmpBuf := make([]rune, 0, ciTrie.maxDepth)
 	buf := make([]rune, 0, len(s))
 
@@ -53,27 +62,26 @@ func Camel(s string, ucFirst bool) string {
 	return string(buf)
 }
 
-// Snake returns a snake cased string.
+// Snake returns a snake_cased string with all lowercase letters.
 func Snake(s string) string {
 	return delimitedCase(s, snakeDelim, false)
 }
 
-// SnakeUpper returns a snake cased string with all upper case letters.
+// SnakeUpper returns a SNAKE_CASED string with all upper case letters.
 func SnakeUpper(s string) string {
 	return delimitedCase(s, snakeDelim, true)
 }
 
-// Kebab returns a kebab cased string.
+// Kebab returns a kebab-cased string with all lowercase letters.
 func Kebab(s string) string {
 	return delimitedCase(s, kebabDelim, false)
 }
 
-// KebabUpper returns a kebab cased string with all upper case letters.
+// KebabUpper returns a KEBAB-CASED string with all upper case letters.
 func KebabUpper(s string) string {
 	return delimitedCase(s, kebabDelim, true)
 }
 
-// Snake returns a snake cased string.
 func delimitedCase(s string, delim rune, upper bool) string {
 	buf := make([]rune, 0, len(s)*2)
 

--- a/kace_bench_test.go
+++ b/kace_bench_test.go
@@ -6,7 +6,13 @@ import (
 
 func BenchmarkCamel4(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		_ = Camel("this_is_a_test", true)
+		_ = Camel("this_is_a_test")
+	}
+}
+
+func BenchmarkPascal4(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_ = Pascal("this_is_a_test")
 	}
 }
 

--- a/kace_example_test.go
+++ b/kace_example_test.go
@@ -9,8 +9,8 @@ import (
 func Example() {
 	s := "this is a test."
 
-	fmt.Println(kace.Camel(s, false))
-	fmt.Println(kace.Camel(s, true))
+	fmt.Println(kace.Camel(s))
+	fmt.Println(kace.Pascal(s))
 
 	fmt.Println(kace.Snake(s))
 	fmt.Println(kace.SnakeUpper(s))

--- a/kace_unit_test.go
+++ b/kace_unit_test.go
@@ -4,46 +4,61 @@ import (
 	"testing"
 )
 
-func TestUnitCamel(t *testing.T) {
+func TestUnitPascal(t *testing.T) {
 	var tests = []struct {
-		i   string
-		ucf bool
-		o   string
+		i string
+		o string
 	}{
-		{"This is a test", false, "thisIsATest"},
-		{"This is a test", true, "ThisIsATest"},
-		{"this is a test3", true, "ThisIsATest3"},
-		{"this is 4 test", true, "ThisIs4Test"},
-		{"5this is a test", true, "5ThisIsATest"},
-		{"this_is_a_test", false, "thisIsATest"},
-		{"this_is_a_test", true, "ThisIsATest"},
-		{"this is a test.", false, "thisIsATest"},
-		{"This is a test.", true, "ThisIsATest"},
-		{"this.is.a.Test", false, "thisIsATest"},
-		{"This.is.a.Test", true, "ThisIsATest"},
-		{"AndThisToo", false, "andThisToo"},
-		{"andThisToo", false, "andThisToo"},
-		{"andThisToo", true, "AndThisToo"},
-		{"AndThisToo", true, "AndThisToo"},
-		{"this http conn", false, "thisHTTPConn"},
-		{"this http conn", true, "ThisHTTPConn"},
-		{"this_https_conn", false, "thisHTTPSConn"},
-		{"this_http_scan", false, "thisHTTPScan"},
-		{"this_https_conn", true, "ThisHTTPSConn"},
-		{"this_http_scan", true, "ThisHTTPScan"},
-		{"willid mess it up", false, "willidMessItUp"},
-		{"willid mess it up", true, "WillidMessItUp"},
-		{"willid_mess_it_up", false, "willidMessItUp"},
-		{"willid_mess_it_up", true, "WillidMessItUp"},
-		{"http_first_lower", false, "httpFirstLower"},
-		{"http_first_upper", true, "HTTPFirstUpper"},
-		{"ahttp_lower", false, "ahttpLower"},
-		{"ahttp_upper", true, "AhttpUpper"},
+		{"This is a test", "ThisIsATest"},
+		{"this is a test", "ThisIsATest"},
+		{"this is 4 test", "ThisIs4Test"},
+		{"5this is a test", "5ThisIsATest"},
+		{"this_is_a_test", "ThisIsATest"},
+		{"This is a test.", "ThisIsATest"},
+		{"This.is.a.Test", "ThisIsATest"},
+		{"andThisToo", "AndThisToo"},
+		{"AndThisToo", "AndThisToo"},
+		{"this http conn", "ThisHTTPConn"},
+		{"this_https_conn", "ThisHTTPSConn"},
+		{"this_http_scan", "ThisHTTPScan"},
+		{"willid mess it up", "WillidMessItUp"},
+		{"willid_mess_it_up", "WillidMessItUp"},
+		{"http_first_upper", "HTTPFirstUpper"},
+		{"ahttp_upper", "AhttpUpper"},
 	}
 
 	for _, v := range tests {
 		want := v.o
-		got := Camel(v.i, v.ucf)
+		got := Pascal(v.i)
+		if got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestUnitCamel(t *testing.T) {
+	var tests = []struct {
+		i string
+		o string
+	}{
+		{"this is a test", "thisIsATest"},
+		{"this_is_a_test", "thisIsATest"},
+		{"this is a test.", "thisIsATest"},
+		{"this.is.a.Test", "thisIsATest"},
+		{"AndThisToo", "andThisToo"},
+		{"andThisToo", "andThisToo"},
+		{"this http conn", "thisHTTPConn"},
+		{"this_https_conn", "thisHTTPSConn"},
+		{"this_http_scan", "thisHTTPScan"},
+		{"willid mess it up", "willidMessItUp"},
+		{"willid_mess_it_up", "willidMessItUp"},
+		{"http_first_lower", "httpFirstLower"},
+		{"ahttp_lower", "ahttpLower"},
+	}
+
+	for _, v := range tests {
+		want := v.o
+		got := Camel(v.i)
 		if got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}


### PR DESCRIPTION
This change splits the Camel into two functions, to avoid using
a boolean to define behavior.  Now it is two functions - Camel
for lowercase first letter and Pascal for uppercase first letter.

Also some small tweaking of doc strings.